### PR TITLE
Fixed gamma change and reshade reload on scene change

### DIFF
--- a/ReshadeEffectShaderToggler.ini
+++ b/ReshadeEffectShaderToggler.ini
@@ -76,13 +76,13 @@ FlipBuffer=False
 AmountHashes=0
 
 [Group1_PixelShaders]
-ShaderHash0=4158341598
-ShaderHash1=367008326
-ShaderHash2=261866633
-ShaderHash3=4084183368
-ShaderHash4=2809089175
-ShaderHash5=2455613235
-ShaderHash6=1332475019
+ShaderHash0=367008326
+ShaderHash1=261866633
+ShaderHash2=4158341598
+ShaderHash3=2455613235
+ShaderHash4=1332475019
+ShaderHash5=4084183368
+ShaderHash6=2809089175
 ShaderHash7=1983890234
 ShaderHash8=1464256434
 ShaderHash9=2025719463
@@ -143,10 +143,9 @@ FlipBuffer=False
 AmountHashes=0
 
 [Group2_PixelShaders]
-ShaderHash0=1006694125
-ShaderHash1=4076256744
-ShaderHash2=4176838410
-AmountHashes=3
+ShaderHash0=4076256744
+ShaderHash1=4176838410
+AmountHashes=2
 
 [Group2_ComputeShaders]
 AmountHashes=0
@@ -245,11 +244,11 @@ AmountHashes=0
 [Group4_PixelShaders]
 ShaderHash0=4084183368
 ShaderHash1=2809089175
-ShaderHash2=3261677874
-ShaderHash3=2294943294
-ShaderHash4=2820232588
+ShaderHash2=2294943294
+ShaderHash3=3261677874
+ShaderHash4=331516824
 ShaderHash5=1964475649
-ShaderHash6=331516824
+ShaderHash6=2820232588
 ShaderHash7=3930188368
 ShaderHash8=1853137649
 ShaderHash9=3645887308
@@ -307,8 +306,8 @@ AmountHashes=0
 ShaderHash0=391640091
 ShaderHash1=3236058778
 ShaderHash2=887612551
-ShaderHash3=1695458953
-ShaderHash4=2431976643
+ShaderHash3=2431976643
+ShaderHash4=1695458953
 ShaderHash5=1057346571
 ShaderHash6=2923325900
 ShaderHash7=4067982083
@@ -328,11 +327,11 @@ UsePreviousValue1=False
 Offset2=48
 Variable2=mat_ViewInv
 UsePreviousValue2=False
-Offset3=160
-Variable3=mat_ViewProjInv
+Offset3=0
+Variable3=mat_View
 UsePreviousValue3=False
-Offset4=0
-Variable4=mat_View
+Offset4=160
+Variable4=mat_ViewProjInv
 UsePreviousValue4=False
 Offset5=96
 Variable5=mat_ViewProj
@@ -478,8 +477,8 @@ AmountHashes=0
 [Group8_PixelShaders]
 ShaderHash0=1132949329
 ShaderHash1=466957953
-ShaderHash2=1825454019
-ShaderHash3=3601637036
+ShaderHash2=3601637036
+ShaderHash3=1825454019
 AmountHashes=4
 
 [Group8_ComputeShaders]

--- a/ReshadeEffectShaderToggler.ini
+++ b/ReshadeEffectShaderToggler.ini
@@ -76,13 +76,13 @@ FlipBuffer=False
 AmountHashes=0
 
 [Group1_PixelShaders]
-ShaderHash0=367008326
-ShaderHash1=261866633
-ShaderHash2=4158341598
-ShaderHash3=2455613235
-ShaderHash4=1332475019
-ShaderHash5=4084183368
-ShaderHash6=2809089175
+ShaderHash0=4158341598
+ShaderHash1=367008326
+ShaderHash2=261866633
+ShaderHash3=4084183368
+ShaderHash4=2809089175
+ShaderHash5=2455613235
+ShaderHash6=1332475019
 ShaderHash7=1983890234
 ShaderHash8=1464256434
 ShaderHash9=2025719463
@@ -143,12 +143,10 @@ FlipBuffer=False
 AmountHashes=0
 
 [Group2_PixelShaders]
-ShaderHash0=3865947726
+ShaderHash0=1006694125
 ShaderHash1=4076256744
-ShaderHash2=2966694105
-ShaderHash3=1823062889
-ShaderHash4=3759127293
-AmountHashes=5
+ShaderHash2=4176838410
+AmountHashes=3
 
 [Group2_ComputeShaders]
 AmountHashes=0
@@ -165,10 +163,9 @@ RenderSRVPipelineSlot=1
 RenderSRVDescriptorIndex=0
 RenderSRVShaderStage=0
 RenderTargetIndex=0
-InvocationLocation=0
+InvocationLocation=1
 MatchSwapchainResolutionOnly=2
 RequeueAfterRTMatchingFailure=True
-Techniques=AutoHDR [AutoHDR.fx],AdvancedAutoHDR [AdvancedAutoHDR.fx]
 AllowAllTechniques=True
 TechniqueExceptions=True
 ProvideTextureBinding=False
@@ -248,11 +245,11 @@ AmountHashes=0
 [Group4_PixelShaders]
 ShaderHash0=4084183368
 ShaderHash1=2809089175
-ShaderHash2=2294943294
-ShaderHash3=3261677874
-ShaderHash4=331516824
+ShaderHash2=3261677874
+ShaderHash3=2294943294
+ShaderHash4=2820232588
 ShaderHash5=1964475649
-ShaderHash6=2820232588
+ShaderHash6=331516824
 ShaderHash7=3930188368
 ShaderHash8=1853137649
 ShaderHash9=3645887308
@@ -310,8 +307,8 @@ AmountHashes=0
 ShaderHash0=391640091
 ShaderHash1=3236058778
 ShaderHash2=887612551
-ShaderHash3=2431976643
-ShaderHash4=1695458953
+ShaderHash3=1695458953
+ShaderHash4=2431976643
 ShaderHash5=1057346571
 ShaderHash6=2923325900
 ShaderHash7=4067982083
@@ -331,11 +328,11 @@ UsePreviousValue1=False
 Offset2=48
 Variable2=mat_ViewInv
 UsePreviousValue2=False
-Offset3=0
-Variable3=mat_View
+Offset3=160
+Variable3=mat_ViewProjInv
 UsePreviousValue3=False
-Offset4=160
-Variable4=mat_ViewProjInv
+Offset4=0
+Variable4=mat_View
 UsePreviousValue4=False
 Offset5=96
 Variable5=mat_ViewProj
@@ -481,8 +478,8 @@ AmountHashes=0
 [Group8_PixelShaders]
 ShaderHash0=1132949329
 ShaderHash1=466957953
-ShaderHash2=3601637036
-ShaderHash3=1825454019
+ShaderHash2=1825454019
+ShaderHash3=3601637036
 AmountHashes=4
 
 [Group8_ComputeShaders]


### PR DESCRIPTION
- Fixed bug where reshade reloads the config every scene change
- Fixed bug where REST causes occasional darkening of the screen by some various effects, which stack causing an obnoxious on-off screen darkening effect, most noticeable in cutscenes and when the UI is turned off